### PR TITLE
fix the "sed: illegal option -- r" error on macOS

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -16,7 +16,7 @@ get_versions_href(){
 }
 
 remove_href_prefix(){
-  sed -r 's/href="//'
+  sed 's/href="//'
 }
 
 unlist_headers_hrefs(){


### PR DESCRIPTION
The regular expression doesn't need to use the "-r" parameter.